### PR TITLE
Fetch NW alarmlevel only once a day

### DIFF
--- a/custom_components/hochwasserportal/api.py
+++ b/custom_components/hochwasserportal/api.py
@@ -170,7 +170,7 @@ class HochwasserPortalAPI:
             )
             data = json_data.json()
             # Parse data
-            self.name = data[0]["station_name"]
+            self.name = data[0]["station_name"] + " " + data[0]["WTO_OBJECT"]
             self.url = (
                 "https://hochwasserportal.nrw/lanuv/data/internet/stations/100/"
                 + self.ident[3:]

--- a/custom_components/hochwasserportal/manifest.json
+++ b/custom_components/hochwasserportal/manifest.json
@@ -9,6 +9,6 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/stephan192/hochwasserportal/issues",
   "loggers": ["hochwasserportal"],
-  "requirements": ["requests>=2.23.0,<3", "lxml>=4.6.2,<5", "bs4==0.0.1"],
+  "requirements": ["requests>=2.23.0,<3", "lxml>=4.6.2,<5", "bs4==0.0.1", "cachetools==5.3.1"],
   "version": "0.0.5"
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 requests==2.31.0
+cachetools==5.3.1


### PR DESCRIPTION
* introduce caching to reduce the number of requests to NW alarmlevel (which are static)
* apply the same scheme to soups, for better code readabilty, although we don't use caching there (yet)